### PR TITLE
Replace Java SPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,27 +43,16 @@ The security provider must be installed before it will work.
 
 ### Installing Dynamically
 
-To set the provider from inside a running JVM, call `Security.addProvider` and then call `setAsDefault()`.
-
 ```java
-DebugJSSEProvider provider = new DebugJSSEProvider();
-Security.addProvider(provider);
-provider.setAsDefault();
-```
-
-For convenience, you can call the `enable` method which does the same as the above:
-
-```java
-DebugJSSEProvider provider = DebugJSSEProvider.enable();
+DebugJSSEProvider provider = DebugJSSEProvider.enable();)
 ```
 
 ### Installing Statically
 
-You can install the [provider statically](https://docs.oracle.com/javase/8/docs/technotes/guides/security/crypto/CryptoSpec.html#ProviderInstalling) and then use it from the command line when you want to:
+You can install the [provider statically](https://docs.oracle.com/javase/9/security/java-secure-socket-extension-jsse-reference-guide.htm#JSSEC-GUID-8BC473B2-CD64-4E8B-8136-80BB286091B1) by adding the provider as the highest priority item in `<java-home>/conf/security/java.security`:
 
 ```bash
-export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStoreProvider=debugPKIX"
-export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Djavax.net.ssl.keyStoreProvider=debugSunX509"
+security.provider.1=debugJSSE|com.tersesystems.debugjsse.DebugJSSEProvider
 ```
 
 ## Setting Debug

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a JSSE provider that provides logging for entrance and exit of the trust
 
 This works on all JSSE implementations, but is transparent, and logs before and after every call.
 
+This only works on "SunJSSE" right now.
+
 More info in the [blog post](https://tersesystems.com/blog/2018/07/27/debug-java-tls-ssl-provider/).
 
 ## Installation
@@ -26,7 +28,7 @@ Packages are hosted on jCenter:
 <dependency>
     <groupId>com.tersesystems.debugjsse</groupId>
     <artifactId>debugjsse</artifactId>
-    <version>0.3.5</version><!-- see badge for latest version -->
+    <version>0.5.0</version><!-- see badge for latest version -->
 </dependency>
 ```
 
@@ -34,7 +36,7 @@ Packages are hosted on jCenter:
 
 ```
 resolvers += Resolver.jcenterRepo 
-libraryDependencies += "com.tersesystems.debugjsse" % "debugjsse" % "0.3.5"
+libraryDependencies += "com.tersesystems.debugjsse" % "debugjsse" % "0.5.0"
 ```
 
 ## Installing Provider
@@ -43,8 +45,10 @@ The security provider must be installed before it will work.
 
 ### Installing Dynamically
 
+Calling `enable` will set the debug provider at the highest level, so it preempts "SunJSSE" and then delegates to it.
+
 ```java
-DebugJSSEProvider provider = DebugJSSEProvider.enable();)
+DebugJSSEProvider provider = DebugJSSEProvider.enable();
 ```
 
 ### Installing Statically
@@ -151,13 +155,15 @@ public class Main {
 Produces the output:
 
 ```
-2018-07-28 09:44:28,467 DEBUG [main] - enter: javax.net.ssl.TrustManagerFactory@27abe2cd.init: args = KeyStore([])
-2018-07-28 09:44:28,470 DEBUG [main] - exit:  javax.net.ssl.TrustManagerFactory@27abe2cd.init: args = KeyStore([]) => null
-2018-07-28 09:44:28,470 DEBUG [main] - enter: javax.net.ssl.TrustManagerFactory@27abe2cd.getTrustManagers()
-2018-07-28 09:44:28,471 DEBUG [main] - exit:  javax.net.ssl.TrustManagerFactory@27abe2cd.getTrustManagers() => [DebugX509ExtendedTrustManager@1151020327(sun.security.ssl.X509TrustManagerImpl@5479e3f)]
-2018-07-28 09:44:28,471 DEBUG [main] - enter: sun.security.ssl.X509TrustManagerImpl@5479e3f.getAcceptedIssuers()
-2018-07-28 09:44:28,472 DEBUG [main] - exit:  sun.security.ssl.X509TrustManagerImpl@5479e3f.getAcceptedIssuers() => []
-trustManager = []
+2018-08-05 11:47:15,108 DEBUG [main] - enter: javax.net.ssl.SSLContext@50cbc42f.init(keyManagers = null, trustManagers = null, secureRandom = null)
+2018-08-05 11:47:15,111 DEBUG [main] - enter: trustManagerFactory1-1533494835111@1265210847.init: args = null
+2018-08-05 11:47:15,184 DEBUG [main] - exit:  trustManagerFactory1-1533494835111@1265210847.init: args = null => null
+2018-08-05 11:47:15,184 DEBUG [main] - enter: trustManagerFactory1-1533494835111@1265210847.getTrustManagers()
+2018-08-05 11:47:15,185 DEBUG [main] - exit:  trustManagerFactory1-1533494835111@1265210847.getTrustManagers() => [trustManager1-1533494835185@627185331]
+2018-08-05 11:47:15,186 DEBUG [main] - exit:  javax.net.ssl.SSLContext@50cbc42f.init(keyManagers = null, trustManagers = null, secureRandom = null) => null
+2018-08-05 11:47:15,186 DEBUG [main] - enter: javax.net.ssl.SSLContext@50cbc42f.createSSLEngine()
+2018-08-05 11:47:15,190 DEBUG [main] - exit:  javax.net.ssl.SSLContext@50cbc42f.createSSLEngine() => 2a18f23c[SSLEngine[hostname=null port=-1] SSL_NULL_WITH_NULL_NULL]
+sslEngine = 2a18f23c[SSLEngine[hostname=null port=-1] SSL_NULL_WITH_NULL_NULL]
 ```
 
 ## Releasing

--- a/src/main/java/com/tersesystems/debugjsse/Debug.java
+++ b/src/main/java/com/tersesystems/debugjsse/Debug.java
@@ -1,25 +1,35 @@
 package com.tersesystems.debugjsse;
 
-
 import javax.net.ssl.*;
-import java.security.KeyStore;
 
 public interface Debug {
+
+    // Java type system not up to extending multiple generic types due to type erasure
+    // https://softwareengineering.stackexchange.com/questions/219427/implementing-multiple-generic-interfaces-in-java
+    //    public interface GenericDebug<T> {
+    //        void enter(T delegate, String method, Object[] args);
+    //        <R> R exit(T delegate, String method, R result, Object[] args);
+    //        void exception(T delegate, String method, Exception e, Object[] args);
+    //    }
+
     void enter(X509ExtendedTrustManager delegate, String method, Object[] args);
-    void enter(X509ExtendedKeyManager delegate, String method, Object[] args);
-
     <T> T exit(X509ExtendedTrustManager delegate, String method, T result, Object[] args);
-    <T> T exit(X509ExtendedKeyManager delegate, String method, T result, Object[] args);
-
     void exception(X509ExtendedTrustManager delegate, String method, Exception e, Object[] args);
+
+    void enter(X509ExtendedKeyManager delegate, String method, Object[] args);
+    <T> T exit(X509ExtendedKeyManager delegate, String method, T result, Object[] args);
     void exception(X509ExtendedKeyManager delegate, String method, Exception e, Object[] args);
 
     void enter(KeyManagerFactory factory, Object[] args);
-    void enter(TrustManagerFactory factory, Object[] args);
-
-    <T> T exit(TrustManagerFactory factory, T result, Object[] args);
     <T> T exit(KeyManagerFactory factory, T result, Object[] args);
-
-    void exception(TrustManagerFactory factory, Exception e, Object[] args);
     void exception(KeyManagerFactory factory, Exception e, Object[] args);
+
+    void enter(TrustManagerFactory factory, Object[] args);
+    <T> T exit(TrustManagerFactory factory, T result, Object[] args);
+    void exception(TrustManagerFactory factory, Exception e, Object[] args);
+
+    void enter(SSLContext context, String method, Object[] args);
+    <T> T exit(SSLContext context, String method,  T result, Object[] args);
+    void exception(SSLContext context, String method, Exception e, Object[] args);
+
 }

--- a/src/main/java/com/tersesystems/debugjsse/DebugKeyManagerFactorySpi.java
+++ b/src/main/java/com/tersesystems/debugjsse/DebugKeyManagerFactorySpi.java
@@ -20,7 +20,7 @@ public abstract class DebugKeyManagerFactorySpi extends KeyManagerFactorySpi {
         Object[] args = { keyStore, chars };
         debug.enter(factory, args);
         try {
-            factory = KeyManagerFactory.getInstance(getAlgorithm());
+            factory = KeyManagerFactory.getInstance(getAlgorithm(), "SunJSSE");
             factory.init(keyStore, chars);
             debug.exit(factory, null, args);
         } catch (RuntimeException e) {
@@ -35,6 +35,9 @@ public abstract class DebugKeyManagerFactorySpi extends KeyManagerFactorySpi {
         } catch (UnrecoverableKeyException e) {
             debug.exception(factory, e, args);
             throw e;
+        } catch (NoSuchProviderException e) {
+            debug.exception(factory, e, args);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/tersesystems/debugjsse/DebugSSLContextSpi.java
+++ b/src/main/java/com/tersesystems/debugjsse/DebugSSLContextSpi.java
@@ -1,0 +1,137 @@
+package com.tersesystems.debugjsse;
+
+import javax.net.ssl.*;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SecureRandom;
+
+public class DebugSSLContextSpi extends SSLContextSpi {
+
+    public static final String SUN_JSSE = "SunJSSE";
+
+    protected Debug debug = DebugJSSEProvider.debug;
+
+    protected SSLContext delegate;
+
+    public static class TLS10Context extends DebugSSLContextSpi {
+        public TLS10Context() throws NoSuchAlgorithmException, NoSuchProviderException {
+            delegate = SSLContext.getInstance("TLSv1", SUN_JSSE);
+        }
+    }
+
+    public static class TLS11Context extends DebugSSLContextSpi {
+        public TLS11Context() throws NoSuchAlgorithmException, NoSuchProviderException {
+            delegate = SSLContext.getInstance("TLSv1.1", SUN_JSSE);
+        }
+    }
+
+    public static class TLS12Context extends DebugSSLContextSpi {
+        public TLS12Context() throws NoSuchAlgorithmException, NoSuchProviderException {
+            delegate = SSLContext.getInstance("TLSv1.2", SUN_JSSE);
+        }
+    }
+
+    public static class TLSContext extends DebugSSLContextSpi {
+        public TLSContext() throws NoSuchAlgorithmException, NoSuchProviderException {
+            delegate = SSLContext.getInstance("TLS", SUN_JSSE);
+        }
+    }
+
+    @Override
+    protected void engineInit(KeyManager[] km, TrustManager[] tm, SecureRandom sr) throws KeyManagementException {
+        String method = "init";
+        Object[] args = { km, tm, sr };
+        debug.enter(delegate, method, args);
+        try {
+            delegate.init(km, tm, sr);
+            debug.exit(delegate, method, null, args);
+        } catch (KeyManagementException e) {
+            debug.exception(delegate, method, e, args);
+            throw e;
+        } catch (RuntimeException e) {
+            debug.exception(delegate, method, e, args);
+            throw e;
+        }
+    }
+
+    @Override
+    protected SSLSocketFactory engineGetSocketFactory() {
+        String method = "getSocketFactory";
+        debug.enter(delegate, method, null);
+        try {
+            SSLSocketFactory result = delegate.getSocketFactory();
+            return debug.exit(delegate, method, result, null);
+        } catch (RuntimeException e) {
+            debug.exception(delegate, method, e, null);
+            throw e;
+        }
+    }
+
+    @Override
+    protected SSLServerSocketFactory engineGetServerSocketFactory() {
+        String method = "getServerSocketFactory";
+        debug.enter(delegate, method, null);
+        try {
+            SSLServerSocketFactory result = delegate.getServerSocketFactory();
+            return debug.exit(delegate, method, result, null);
+        } catch (RuntimeException e) {
+            debug.exception(delegate, method, e, null);
+            throw e;
+        }
+    }
+
+    @Override
+    protected SSLEngine engineCreateSSLEngine() {
+        String method = "createSSLEngine";
+        debug.enter(delegate, method, null);
+        try {
+            SSLEngine result = delegate.createSSLEngine();
+            return debug.exit(delegate, method, result, null);
+        } catch (RuntimeException e) {
+            debug.exception(delegate, method, e, null);
+            throw e;
+        }
+    }
+
+    @Override
+    protected SSLEngine engineCreateSSLEngine(String host, int port) {
+        String method = "createSSLEngine";
+        Object[] args = {host, port};
+        debug.enter(delegate, method, args);
+        try {
+            SSLEngine result = delegate.createSSLEngine(host, port);
+            return debug.exit(delegate, method, result, args);
+        } catch (RuntimeException e) {
+            debug.exception(delegate, method, e, args);
+            throw e;
+        }
+    }
+
+    @Override
+    protected SSLSessionContext engineGetServerSessionContext() {
+        String method = "getServerSessionContext";
+        debug.enter(delegate, method, null);
+        try {
+            SSLSessionContext result = delegate.getServerSessionContext();
+            return debug.exit(delegate, method, result, null);
+        } catch (RuntimeException e) {
+            debug.exception(delegate, method, e, null);
+            throw e;
+        }
+    }
+
+    @Override
+    protected SSLSessionContext engineGetClientSessionContext() {
+        String method = "getClientSessionContext";
+        debug.enter(delegate, method, null);
+        try {
+            SSLSessionContext result = delegate.getClientSessionContext();
+            return debug.exit(delegate, method, result, null);
+        } catch (RuntimeException e) {
+            debug.exception(delegate, method, e, null);
+            throw e;
+        }
+    }
+
+}

--- a/src/main/java/com/tersesystems/debugjsse/DebugTrustManagerFactorySpi.java
+++ b/src/main/java/com/tersesystems/debugjsse/DebugTrustManagerFactorySpi.java
@@ -1,10 +1,7 @@
 package com.tersesystems.debugjsse;
 
 import javax.net.ssl.*;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
+import java.security.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,8 +16,8 @@ public abstract class DebugTrustManagerFactorySpi extends TrustManagerFactorySpi
      */
     public abstract String getAlgorithm();
 
-    public DebugTrustManagerFactorySpi() throws NoSuchAlgorithmException {
-        factory = TrustManagerFactory.getInstance(getAlgorithm());
+    public DebugTrustManagerFactorySpi() throws NoSuchAlgorithmException, NoSuchProviderException {
+        factory = TrustManagerFactory.getInstance(getAlgorithm(), "SunJSSE");
     }
 
     @Override

--- a/src/test/java/Main.java
+++ b/src/test/java/Main.java
@@ -3,12 +3,7 @@ import com.tersesystems.debugjsse.Debug;
 import com.tersesystems.debugjsse.DebugJSSEProvider;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509ExtendedTrustManager;
-import java.security.KeyStore;
-import java.security.cert.X509Certificate;
-import java.util.Arrays;
+import javax.net.ssl.*;
 
 public class Main {
 
@@ -33,16 +28,12 @@ public class Main {
 
     public static void main(String[] args) throws Exception {
         DebugJSSEProvider.enable().setDebug(slf4jDebug);
-        KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-        ks.load(null, "changeit".toCharArray());
 
-        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        trustManagerFactory.init(ks);
-        TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
-        X509ExtendedTrustManager trustManager = (X509ExtendedTrustManager) trustManagers[0];
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, null, null);
+        SSLEngine sslEngine = sslContext.createSSLEngine();
 
-        X509Certificate[] acceptedIssuers = trustManager.getAcceptedIssuers();
-        System.out.println("trustManager = " + Arrays.toString(acceptedIssuers));
+        System.out.println("sslEngine = " + sslEngine);
     }
 
     //


### PR DESCRIPTION
Add DebugSSLContext.

Use all the same algorithms as SunJSSE provider, but install ourselves as preferred, which is much less intrusive overall and still lets us call the same algorithm with a different provider.